### PR TITLE
Allow running scripts directly

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -19,9 +19,14 @@ import tkinter as tk
 from tkinter import filedialog, messagebox
 from tkinter import scrolledtext
 
-from .directory_scanner import scan_course_folder
-from .file_processor import read_text_file, extract_audio_and_transcribe
-from .api_handler import ApiManager, call_api
+try:  # Support running as a script or module
+    from .directory_scanner import scan_course_folder
+    from .file_processor import read_text_file, extract_audio_and_transcribe
+    from .api_handler import ApiManager, call_api
+except ImportError:  # pragma: no cover - fallback for direct execution
+    from directory_scanner import scan_course_folder
+    from file_processor import read_text_file, extract_audio_and_transcribe
+    from api_handler import ApiManager, call_api
 
 
 class VideoAnalyzerApp:

--- a/main.py
+++ b/main.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 
 import tkinter as tk
 
-from .gui import VideoAnalyzerApp
+try:  # Allow running as a script or a module
+    from .gui import VideoAnalyzerApp
+except ImportError:  # pragma: no cover - fallback for direct execution
+    from gui import VideoAnalyzerApp
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- Support executing `main.py` and `gui.py` directly by falling back to local imports when package context is missing.

## Testing
- `python -m py_compile main.py gui.py directory_scanner.py file_processor.py api_handler.py`
- `python main.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68b13a2ae7d48330a71aee335668214b